### PR TITLE
include wget in packages synced for eMMC install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -29,7 +29,7 @@ UBOOTFILE="nv_uboot-spring.kpart.gz"
 if [ $DEVICE = $EMMC ]; then
     # for eMMC we need to get some things before we can partition
     echo -e "\n[archlinuxfr]\nSigLevel = Never\nServer = http://repo.archlinux.fr/arm\n" >> /etc/pacman.conf
-    pacman -Syyu yaourt devtools-alarm base-devel git libyaml parted dosfstools
+    pacman -Syyu yaourt devtools-alarm base-devel git libyaml parted dosfstools wget
     log "When prompted to modify PKGBUILD for trousers, set arch to armv7h"
     yaourt -Syy trousers vboot-utils
 fi


### PR DESCRIPTION
The current Arch Linux ARM base install does not include wget, so if one tries
to run the install script from within the bare USB install, line 56 (fetching
the install image) will fail.

This can happen for instance when running the previously downloaded install.sh
from the ChromeOS state partition.
