### PR TITLE
Tell pacman which libgl provider to install

### DIFF
--- a/post-install.sh
+++ b/post-install.sh
@@ -3,6 +3,7 @@ REPOPATH="https://raw2.github.com/omgmog/archarm-usb-hp-chromebook-11/master/"
 
 # Update pacman and install some important things
 pacman -Syyu
+pacman -S mesa-libgl
 pacman -S mate xorg-server xorg-xinit xorg-server-utils xterm alsa-utils xf86-video-fbdev xf86-input-synaptics
 pacman -S lightdm lightdm-gtk2-greeter
 systemctl enable lightdm


### PR DESCRIPTION
The gpu-viv-bin-mx6q-dfb, gpu-viv-bin-mx6q-fb, gpu-viv-bin-mx6q-x11 and gpu-viv-bin-mx6q-wl libgl providers don't work for some reason.
This will ensure a working libgl provider is installed.
