### PR TITLE
EMMC extra packages repo directly in pacman.conf

### DIFF
--- a/deps/pacman.conf
+++ b/deps/pacman.conf
@@ -88,6 +88,10 @@ Include = /etc/pacman.d/mirrorlist
 [aur]
 Include = /etc/pacman.d/mirrorlist
 
+[archlinuxfr]
+SigLevel = Never
+Server = http://repo.archlinux.fr/arm
+
 # An example of a custom package repository.  See the pacman manpage for
 # tips on creating your own repositories.
 #[custom]

--- a/install.sh
+++ b/install.sh
@@ -40,7 +40,6 @@ wget https://raw.githubusercontent.com/omgmog/archarm-usb-hp-chromebook-11/maste
 chmod +x /usr/local/bin/cgpt
 if [ $DEVICE = $EMMC ]; then
     # for eMMC we need to get some things before we can partition
-    echo -e "\n[archlinuxfr]\nSigLevel = Never\nServer = http://repo.archlinux.fr/arm\n" >> /etc/pacman.conf
     pacman -Syyu packer devtools-alarm base-devel git libyaml parted dosfstools cgpt parted
     log "When prompted to modify PKGBUILD for trousers, set arch to armv7h"
     packer -S trousers vboot-utils


### PR DESCRIPTION
* Added archlinux.fr arm repo to pacman.conf.
* Removed step to add it in the script.

Didn't want to merge direct because I have thought of a potential issue : 
 This will cause problems for people who have installed arch to USB with a previous version of the script.

Should I merge or try to find another solution ? @omgmog 