### PR TITLE
Various fixes to the install.sh script for both USB creation and local install

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ bash install.sh "/dev/sda"
 
 After you've made a USB stick and booted from it, you can download and run the `install.sh` again and install to `/dev/mmcblk0` (the eMMC) for a much nicer/faster Arch experience.
 
+Log in as the *root* user which was created during the install process.  Then, select which wifi network to join:
+```
+wifi-menu mlan0
+```
+
+Then, download and run the install script, but this time on the internal storage:
 ```
 pacman -Syy wget
 wget http://git.io/A3D0 -O install.sh

--- a/README.md
+++ b/README.md
@@ -27,15 +27,16 @@ On your Chromebook with Developer Mode enabled:
 sudo su -
 cd /tmp
 wget http://git.io/A3D0 -O install.sh
-sh install.sh "/dev/sda"
+bash install.sh "/dev/sda"
 ```
+**NOTE**: This needs to be run with /bin/bash, not /bin/sh, which is ash.
 
 After you've made a USB stick and booted from it, you can download and run the `install.sh` again and install to `/dev/mmcblk0` (the eMMC) for a much nicer/faster Arch experience.
 
 ```
 pacman -Syy wget
 wget http://git.io/A3D0 -O install.sh
-sh install.sh "/dev/mmcblk0"
+bash install.sh "/dev/mmcblk0"
 ```
 Regarding the modification of the PKGBUILD for `trousers`:
 

--- a/fix-systemd.sh
+++ b/fix-systemd.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-pacman -Syy
+pacman -Sy
 pacman -Ud /systemd-212-3-armv7h.pkg.tar.xz
 echo "Please Set a Root password"
 passwd root

--- a/install.sh
+++ b/install.sh
@@ -51,10 +51,13 @@ if [ $DEVICE = $EMMC ]; then
 	rm -f /usr/sbin
     fi
     # for eMMC we need to get some things before we can partition
-    pacman -Syu packer devtools-alarm base-devel git libyaml parted dosfstools parted
+    pacman -Syu --needed packer devtools-alarm base-devel git libyaml parted dosfstools parted
+    pacman -S --needed --noconfirm vboot-utils 
     log "When prompted to modify PKGBUILD for trousers, set arch to armv7h"
-    packer -S trousers vboot-utils
-    if [ ! -L /usr/sbin ]; then
+    useradd -c 'Build user' -m build
+    su -c "packer -S trousers" build
+    userdel -r build > /dev/null 2>&1
+    if [ ! -L /usr/sbin ] && [ ! -d /usr/sbin ]; then
 	ln -s /usr/bin /usr/sbin
     fi
 else
@@ -70,7 +73,7 @@ else
 fi
 
 log "Creating volumes on ${DEVICE}"
-for mnt in `mount | grep ${DEVICE} | awk '{print $1}';do
+for mnt in `mount | grep ${DEVICE} | awk '{print $1}'`;do
     umount ${mnt}
 done
 parted ${DEVICE} mklabel gpt
@@ -95,15 +98,17 @@ else
     log "Looks like you already have ${OSFILE}"
 fi
 log "Installing Arch to ${P3} (this will take a moment...)"
-for mnt in `mount | grep ${DEVICE} | awk '{print $1}';do
+for mnt in `mount | grep ${DEVICE} | awk '{print $1}'`;do
     umount ${mnt}
 done
 mkdir -p root
 mount -o exec $P3 root
-tar -xf ${OSFILE} -C root
+tar -xf ${OSFILE} -C root > /dev/null 2>&1
 
 log "Preparing system for chroot"
-cp install.sh root/install.sh
+if [ $DEVICE != $EMMC ]; then
+    cp install.sh root/install.sh
+fi
 rm root/etc/resolv.conf
 cp /etc/resolv.conf root/etc/resolv.conf
 mount -t proc proc root/proc/
@@ -146,7 +151,7 @@ fi
 if [ $DEVICE = $EMMC ]; then
     echo "root=${P3} rootwait rw quiet lsm.module_locking=0" >config.txt
 
-    vbutil_kernel \
+    /usr/sbin/vbutil_kernel \
     --pack arch-eMMC.kpart \
     --keyblock /usr/share/vboot/devkeys/kernel.keyblock \
     --signprivate /usr/share/vboot/devkeys/kernel_data_key.vbprivk \

--- a/install.sh
+++ b/install.sh
@@ -43,6 +43,7 @@ UBOOTFILE="nv_uboot-spring.kpart.gz"
 GITHUBUSER="omgmog"
 REPOFILES="https://raw.githubusercontent.com/${GITHUBUSER}/archarm-usb-hp-chromebook-11"
 echo "Getting working cgpt binary"
+mkdir -p /usr/local/bin
 wget ${REPOFILES}/master/deps/cgpt --output-document=/usr/local/bin/cgpt
 chmod +x /usr/local/bin/cgpt
 if [ $DEVICE = $EMMC ]; then
@@ -58,7 +59,7 @@ if [ $DEVICE = $EMMC ]; then
     fi
 else
     log "Ensuring the proper paritioning tools are availible"
-    if (which parted); then 
+    if (which parted > /dev/null 2>&1 ); then 
 	echo "parted is installed. Installation can proceed"
     else 
 	echo "parted must be downloaded !"
@@ -69,7 +70,9 @@ else
 fi
 
 log "Creating volumes on ${DEVICE}"
-umount ${DEVICE}* || echo -n
+for mnt in `mount | grep ${DEVICE} | awk '{print $1}';do
+    umount ${mnt}
+done
 parted ${DEVICE} mklabel gpt
 /usr/local/bin/cgpt create -z ${DEVICE}
 /usr/local/bin/cgpt create ${DEVICE}
@@ -92,7 +95,9 @@ else
     log "Looks like you already have ${OSFILE}"
 fi
 log "Installing Arch to ${P3} (this will take a moment...)"
-umount ${DEVICE}*
+for mnt in `mount | grep ${DEVICE} | awk '{print $1}';do
+    umount ${mnt}
+done
 mkdir -p root
 mount -o exec $P3 root
 tar -xf ${OSFILE} -C root


### PR DESCRIPTION
Added some error handling to help debug things
Cleaned up some logic to deal with the new debug handeling.
Udpated README.md to reflect the new debugging and to add some bit more instructions
Cleaned up some of the pacman handling.
added logic to gen a temp user to use packer for the ```trousers``` build

With this, I can go from a clean ChromeOS install, to a local ArchLinux install.

Some of the cleanup was to make the script easier for non-SysAdmin types to deal with it.  Whilst I have been doing this since kernel 0.92, a lot of folks will not have the background, so I wanted to make it easier and more user-friendly.